### PR TITLE
Move RateLimiter to it's proper spot in the network package (vs utils)

### DIFF
--- a/src/main/kotlin/com/tripl3dogdare/enclave/network/RateLimiter.kt
+++ b/src/main/kotlin/com/tripl3dogdare/enclave/network/RateLimiter.kt
@@ -1,5 +1,6 @@
-package com.tripl3dogdare.enclave.util
+package com.tripl3dogdare.enclave.network
 
+import com.tripl3dogdare.enclave.util.TimerTask
 import org.http4k.core.HttpHandler
 import org.http4k.core.Request
 import org.http4k.core.Response

--- a/src/main/kotlin/com/tripl3dogdare/enclave/network/Rest.kt
+++ b/src/main/kotlin/com/tripl3dogdare/enclave/network/Rest.kt
@@ -3,7 +3,6 @@ package com.tripl3dogdare.enclave.network
 import com.tripl3dogdare.enclave.Enclave
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.tripl3dogdare.enclave.util.RateLimiter
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.runBlocking
 import org.http4k.client.JavaHttpClient


### PR DESCRIPTION
The implementation of RateLimiter is too simplistic and usage-specific to really belong in utils, so it should be moved to network where it belongs.